### PR TITLE
drivers: usb: nrfx: fixes for USB dfu

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -153,7 +153,7 @@ struct usbd_ep_event {
  */
 #define FIFO_ELEM_MIN_SZ	sizeof(struct usbd_ep_event)
 #define FIFO_ELEM_MAX_SZ	sizeof(struct usbd_ep_event)
-#define FIFO_ELEM_COUNT		16
+#define FIFO_ELEM_COUNT		32
 #define FIFO_ELEM_ALIGN		sizeof(unsigned int)
 
 K_MEM_POOL_DEFINE(fifo_elem_pool, FIFO_ELEM_MIN_SZ, FIFO_ELEM_MAX_SZ,

--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1488,7 +1488,9 @@ int usb_dc_ep_read_continue(u8_t ep)
 		return -EINVAL;
 	}
 
-	ep_ctx->buf.curr = ep_ctx->buf.data;
+	if (!ep_ctx->buf.len) {
+		ep_ctx->buf.curr = ep_ctx->buf.data;
+	}
 	ep_ctx->read_complete = true;
 
 	if (ep_ctx->read_pending) {


### PR DESCRIPTION
Hi @pawelzadrozniak , this PR address a couple of issues I found when trying to get the USB DFU to work.
1. There event queue seems too small.
2. The read buffer position is reset unconditionally.

Hope all is well!